### PR TITLE
fix(host): skip VF representors in TryGetInterfaceName

### DIFF
--- a/demo/multus-integration-multiple-resourceclaim/README.md
+++ b/demo/multus-integration-multiple-resourceclaim/README.md
@@ -1,0 +1,339 @@
+# Multus Integration with Multiple Resource Claims Demo
+
+This demo demonstrates advanced integration of DRA SR-IOV driver with Multus CNI using multiple independent resource claims, each attached to different network configurations.
+
+## Overview
+
+This scenario shows:
+- Multiple independent DRA resource claims in a single pod
+- Integration with Multus CNI using different NetworkAttachmentDefinitions
+- Each resource claim attached to its own dedicated network
+- Advanced multi-network configuration for complex networking scenarios
+- Deployment-based workload with isolated network paths
+
+## Components
+
+### 1. Namespace and Networking Setup
+- Creates dedicated namespace (`vf-test9`)
+- **Two NetworkAttachmentDefinitions** with distinct configurations:
+  - `vf-test1`: Resource name `sriov1/vf`, subnet `10.0.2.0/24`
+  - `vf-test2`: Resource name `sriov2/vf`, subnet `10.0.2.0/24`
+- Each network definition represents a separate SR-IOV resource pool
+- Standard SR-IOV CNI settings (VLAN 0, spoofchk on, trust on)
+
+### 2. Multiple Independent Resource Claims
+The configuration uses:
+- **Single ResourceClaimTemplate** (`vf-test9`): Defines the claim specification
+- **Two resourceClaims** in the pod:
+  - `sriov1`: First claim using the template
+  - `sriov2`: Second claim using the template
+- Each claim independently allocates one VF
+- Both claims reference the same template but are separate resource allocations
+
+### 3. Deployment Configuration
+- Uses Deployment for production-like workload management
+- Multus network annotation: `k8s.v1.cni.cncf.io/networks: vf-test1,vf-test2`
+  - Each network maps to a different resource claim
+- Container resources reference both claims:
+  ```yaml
+  resources:
+    claims:
+    - name: sriov1
+    - name: sriov2
+  ```
+- Container with necessary networking capabilities (NET_ADMIN, NET_RAW)
+
+## Key Differences from Other Demos
+
+| Aspect | Multiple VFs (Single Claim) | Multiple Resource Claims |
+|--------|----------------------------|-------------------------|
+| Resource Claims | 1 claim with count=2 | 2 separate claims with count=1 each |
+| VF Allocation | Both VFs from same allocation | Independent VF allocations |
+| Network Attachment | Can use same network | Each claim can use different network |
+| Resource Pools | Single resource pool | Separate resource pools possible |
+| Flexibility | VFs treated as a group | VFs managed independently |
+| Use Case | Homogeneous networking | Heterogeneous networking |
+
+## How It Works
+
+1. **Pod Creation**: Deployment creates pod with two resource claims
+2. **First DRA Allocation**: DRA driver allocates VF for `sriov1` claim
+3. **Second DRA Allocation**: DRA driver allocates VF for `sriov2` claim (independent)
+4. **Multus Processing**: Multus CNI reads network annotations and matches to resource claims
+5. **Interface Creation**: SR-IOV CNI creates two interfaces based on different network definitions
+6. **IP Assignment**: IPAM assigns IP addresses to each interface
+7. **Pod Ready**: Pod starts with cluster network plus two independently managed SR-IOV interfaces
+
+## Network Interface Behavior
+
+With multiple resource claims and Multus:
+1. **Container Interfaces**:
+   - `eth0`: Default pod network (cluster networking)
+   - `net1`: First SR-IOV interface from `sriov1` claim (attached to `vf-test1` network)
+   - `net2`: Second SR-IOV interface from `sriov2` claim (attached to `vf-test2` network)
+
+2. **Resource Mapping**:
+   - `sriov1` claim → `vf-test1` NetworkAttachmentDefinition → `net1` interface
+   - `sriov2` claim → `vf-test2` NetworkAttachmentDefinition → `net2` interface
+
+3. **Network Isolation**:
+   - Each interface can have completely independent configuration
+   - Different VLANs, QoS, IPAM configurations possible
+   - Enables true network separation within a single pod
+
+## Use Cases
+
+Multiple independent resource claims are ideal for:
+- **Network Function Virtualization**: CNFs requiring separate control and data planes
+- **Multi-Tenant Isolation**: Different network paths for different tenants
+- **Separated Traffic Types**: Distinct networks for management, control, and data traffic
+- **5G/Telco Workloads**: Separate interfaces for different 3GPP interfaces (N2, N3, N4, N6)
+- **Compliance Requirements**: Isolated networks for regulatory or security compliance
+- **Hybrid Cloud**: Different networks for intra-cloud and inter-cloud communication
+- **Service Chaining**: Multiple attachment points for complex service chains
+
+## Advanced Networking Scenarios
+
+### Different Resource Pools
+Each NetworkAttachmentDefinition can reference different SR-IOV resource pools:
+- `sriov1/vf`: Could be from Intel NICs
+- `sriov2/vf`: Could be from Mellanox NICs
+- Enables heterogeneous hardware in same pod
+
+### Different Network Configurations
+Each network can have completely different settings:
+- Different VLANs per interface
+- Different QoS policies
+- Different IP subnets
+- Different MTU sizes
+- Different security policies
+
+### Independent Lifecycle Management
+- Each resource claim can be managed independently
+- Supports dynamic attachment/detachment scenarios
+- Enables zero-downtime network reconfiguration
+
+## Usage
+
+1. Deploy the configuration:
+   ```bash
+   kubectl apply -f multus-integration-multiple-resourceclaim.yaml
+   ```
+
+2. Verify deployment:
+   ```bash
+   kubectl get deployment -n vf-test9
+   kubectl get pods -n vf-test9
+   kubectl describe pod -n vf-test9 -l app=pod0
+   ```
+
+3. Check all NetworkAttachmentDefinitions:
+   ```bash
+   kubectl get network-attachment-definitions -n vf-test9
+   kubectl describe network-attachment-definitions vf-test1 -n vf-test9
+   kubectl describe network-attachment-definitions vf-test2 -n vf-test9
+   ```
+
+4. Verify both resource claims:
+   ```bash
+   kubectl get resourceclaim -n vf-test9
+   kubectl describe resourceclaim -n vf-test9
+   ```
+
+5. Check resource claim template:
+   ```bash
+   kubectl get resourceclaimtemplate -n vf-test9
+   kubectl describe resourceclaimtemplate vf-test9 -n vf-test9
+   ```
+
+6. Verify network interfaces in the pod:
+   ```bash
+   # Get pod name
+   POD_NAME=$(kubectl get pods -n vf-test9 -l app=pod0 -o jsonpath='{.items[0].metadata.name}')
+   
+   # List all interfaces
+   kubectl exec -n vf-test9 $POD_NAME -- ip link show
+   
+   # Check all IP addresses
+   kubectl exec -n vf-test9 $POD_NAME -- ip addr show
+   
+   # Verify first SR-IOV interface (from sriov1 claim)
+   kubectl exec -n vf-test9 $POD_NAME -- ip addr show net1
+   
+   # Verify second SR-IOV interface (from sriov2 claim)
+   kubectl exec -n vf-test9 $POD_NAME -- ip addr show net2
+   ```
+
+7. Test connectivity on each interface:
+   ```bash
+   # Test cluster networking (eth0)
+   kubectl exec -n vf-test9 $POD_NAME -- ping -c 3 kubernetes.default.svc.cluster.local
+   
+   # Test first SR-IOV interface (net1 - vf-test1 network)
+   kubectl exec -n vf-test9 $POD_NAME -- ping -I net1 -c 3 <target-ip-1>
+   
+   # Test second SR-IOV interface (net2 - vf-test2 network)
+   kubectl exec -n vf-test9 $POD_NAME -- ping -I net2 -c 3 <target-ip-2>
+   ```
+
+8. Verify resource claim to network mapping:
+   ```bash
+   # Check which VF is allocated to each claim
+   kubectl get resourceclaim -n vf-test9 -o yaml
+   
+   # Verify network attachment status
+   kubectl exec -n vf-test9 $POD_NAME -- ip -d link show net1
+   kubectl exec -n vf-test9 $POD_NAME -- ip -d link show net2
+   ```
+
+## Resource Claim Configuration
+
+The pod specification shows how multiple claims are configured:
+
+```yaml
+spec:
+  containers:
+  - name: ctr0
+    resources:
+      claims:
+      - name: sriov1  # Reference to first claim
+      - name: sriov2  # Reference to second claim
+  resourceClaims:
+  - name: sriov1
+    resourceClaimTemplateName: vf-test9  # Both use same template
+  - name: sriov2
+    resourceClaimTemplateName: vf-test9  # But are independent allocations
+```
+
+## Architecture Benefits
+
+1. **Flexibility**: Each claim can evolve independently
+2. **Scalability**: Easy to add more claims without changing existing ones
+3. **Isolation**: Complete separation between network paths
+4. **Reusability**: Same template used for multiple claims
+5. **Manageability**: Each network can be managed by different teams
+6. **Compliance**: Audit and control each network independently
+
+## Performance Considerations
+
+- **Independent Allocation**: Each VF allocated separately, may come from different PFs
+- **NUMA Awareness**: VFs might be on different NUMA nodes
+- **Resource Constraints**: Requires sufficient VFs across resource pools
+- **Overhead**: Slightly higher management overhead than single claim
+- **Throughput**: Each interface provides full SR-IOV performance
+- **Isolation**: Better isolation but may impact NUMA-local performance
+
+## Prerequisites
+
+- SR-IOV capable network interfaces with multiple VFs configured
+- SR-IOV Network Operator with multiple resource pools configured
+- Multus CNI installed on the cluster
+- At least 2 Virtual Functions available (can be from same or different PFs)
+- DRA-enabled Kubernetes cluster (v1.34+)
+- Appropriate node labeling and SR-IOV configuration
+- IPAM configuration with sufficient IP addresses
+
+## Advanced Configuration Examples
+
+### Different Subnets per Network
+```yaml
+# vf-test1: Management network
+ipam:
+  ranges:
+    - subnet: "192.168.1.0/24"
+
+# vf-test2: Data network  
+ipam:
+  ranges:
+    - subnet: "10.0.0.0/16"
+```
+
+### Different VLAN Configuration
+```yaml
+# vf-test1: VLAN 100
+config: |-
+  {
+    "type": "sriov",
+    "vlan": 100,
+    ...
+  }
+
+# vf-test2: VLAN 200
+config: |-
+  {
+    "type": "sriov",
+    "vlan": 200,
+    ...
+  }
+```
+
+### Mixed Hardware Resources
+```yaml
+# NetworkAttachmentDefinition for Intel NICs
+annotations:
+  k8s.v1.cni.cncf.io/resourceName: intel.com/sriov_netdevice
+
+# NetworkAttachmentDefinition for Mellanox NICs
+annotations:
+  k8s.v1.cni.cncf.io/resourceName: mellanox.com/sriov_netdevice
+```
+
+## Troubleshooting
+
+Common issues and solutions:
+
+1. **Only one VF allocated**:
+   - Verify both resource claims exist: `kubectl get resourceclaim -n vf-test9`
+   - Check if sufficient VFs available in both pools
+   - Review DRA driver logs for allocation failures
+
+2. **Network interface mapping incorrect**:
+   - Verify Multus network order matches resource claim order
+   - Check NetworkAttachmentDefinition resource annotations
+   - Review pod network status annotations
+
+3. **One claim succeeds, other fails**:
+   - Check resource pool availability for each claim
+   - Verify node has VFs for both resource types
+   - Review resource claim events
+
+4. **IP conflicts between interfaces**:
+   - Ensure different subnets for each network
+   - Check IPAM configuration in each NetworkAttachmentDefinition
+   - Verify no subnet overlap
+
+5. **Pod stuck in ContainerCreating**:
+   - Check both resource claims are satisfied: `kubectl describe resourceclaim -n vf-test9`
+   - Verify Multus can find both network definitions
+   - Review kubelet logs for CNI errors
+
+## Cleanup
+
+```bash
+kubectl delete namespace vf-test9
+```
+
+This will clean up all resources including:
+- Deployment and pods
+- Both resource claims
+- ResourceClaimTemplate
+- Both NetworkAttachmentDefinitions
+- Namespace
+
+## Related Demos
+
+- **multus-integration-single-vf**: Multus with single resource claim
+- **multus-integration-multiple-vf**: Multiple VFs in single claim
+- **multiple-vf-claim**: Multiple VFs without Multus
+- **claim-for-deployment**: Deployment patterns with resource claims
+
+## Best Practices
+
+1. **Network Planning**: Plan subnet allocation carefully to avoid conflicts
+2. **Resource Naming**: Use descriptive names for claims and networks
+3. **Documentation**: Document which network serves which purpose
+4. **Monitoring**: Monitor each interface independently
+5. **Testing**: Test failover scenarios between interfaces
+6. **Security**: Apply appropriate network policies per interface
+7. **Resource Limits**: Understand node capacity for multiple allocations
+

--- a/demo/multus-integration-multiple-resourceclaim/multus-integration-multiple-resourceclaim.yaml
+++ b/demo/multus-integration-multiple-resourceclaim/multus-integration-multiple-resourceclaim.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vf-test9
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vf-test1
+  namespace: vf-test9
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: sriov1/vf
+spec:
+  config: |-
+    {
+        "cniVersion": "1.0.0",
+        "name": "vf-test1",
+        "type": "sriov",
+        "vlan": 0,
+        "spoofchk": "on",
+        "trust": "on",
+        "vlanQoS": 0,
+        "logLevel": "info",
+        "ipam": {
+            "type": "host-local",
+            "ranges": [
+                [
+                    {
+                        "subnet": "10.0.2.0/24"
+                    }
+                ]
+            ]
+        }
+    }
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vf-test2
+  namespace: vf-test9
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: sriov2/vf
+spec:
+  config: |-
+    {
+        "cniVersion": "1.0.0",
+        "name": "vf-test2",
+        "type": "sriov",
+        "vlan": 0,
+        "spoofchk": "on",
+        "trust": "on",
+        "vlanQoS": 0,
+        "logLevel": "info",
+        "ipam": {
+            "type": "host-local",
+            "ranges": [
+                [
+                    {
+                        "subnet": "10.0.2.0/24"
+                    }
+                ]
+            ]
+        }
+    }
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: vf-test9
+  name: vf-test9
+spec:
+  spec:
+    devices:
+      requests:
+      - name: vf
+        exactly:
+          deviceClassName: sriovnetwork.k8snetworkplumbingwg.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: vf-test9
+  name: pod0
+  labels:
+    app: pod0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pod0
+  template:
+    metadata:
+      labels:
+        app: pod0
+      annotations:
+        k8s.v1.cni.cncf.io/networks: vf-test1,vf-test2
+    spec:
+      terminationGracePeriodSeconds: 2
+      containers:
+      - name: ctr0
+        image: quay.io/schseba/toolbox:latest
+        command:
+          - /bin/bash
+          - -c
+          - sleep INF
+        securityContext:
+          runAsUser: 0
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+              - NET_ADMIN
+              - NET_RAW
+        resources:
+          claims:
+          - name: sriov1
+          - name: sriov2
+      resourceClaims:
+      - name: sriov1
+        resourceClaimTemplateName: vf-test9
+      - name: sriov2
+        resourceClaimTemplateName: vf-test9

--- a/demo/multus-integration-multiple-vf/README.md
+++ b/demo/multus-integration-multiple-vf/README.md
@@ -1,0 +1,281 @@
+# Multus Integration with Multiple Virtual Functions Demo
+
+This demo demonstrates the integration of DRA SR-IOV driver with Multus CNI for dynamic network attachment using multiple Virtual Functions.
+
+## Overview
+
+This scenario shows:
+- Integration between DRA (Dynamic Resource Allocation) and Multus CNI
+- Multiple SR-IOV Virtual Functions (2 VFs) allocation with Multus network attachments
+- Automatic provisioning of multiple network interfaces through Multus annotations
+- Deployment-based workload with multi-interface SR-IOV networking
+
+## Components
+
+### 1. Namespace and Networking Setup
+- Creates dedicated namespace (`vf-test8`)
+- NetworkAttachmentDefinition with SR-IOV CNI plugin configuration
+- Multus resource annotation: `k8s.v1.cni.cncf.io/resourceName: sriov/vf`
+- IPAM setup using host-local plugin with subnet `10.0.2.0/24`
+- Standard SR-IOV network settings (VLAN 0, spoofchk on, trust on)
+
+### 2. Multi-VF Resource Claim
+The `ResourceClaimTemplate` configuration:
+- **count: 2**: Requests exactly 2 Virtual Functions
+- **deviceClassName**: `sriovnetwork.k8snetworkplumbingwg.io`
+- Automatically integrates with Multus through DRA driver
+- Both VFs share the same network attachment definition
+
+### 3. Deployment Configuration
+- Uses Deployment for production-like workload management
+- Single replica for testing purposes
+- Multus network annotation: `k8s.v1.cni.cncf.io/networks: vf-test1,vf-test1`
+  - Note: Network name is repeated twice for 2 VF attachments
+- Container with necessary networking capabilities (NET_ADMIN, NET_RAW)
+- Resource claim binding for multiple VFs
+
+## Multus Integration with Multiple VFs
+
+This advanced integration provides:
+- **Multiple Network Attachments**: Each VF gets a separate network attachment
+- **Dynamic Multi-Interface Management**: DRA handles lifecycle of multiple VFs
+- **Flexible Network Configuration**: Different or same network definitions per VF
+- **High Availability**: Multiple interfaces for redundancy and failover
+- **Load Balancing**: Traffic distribution across multiple SR-IOV interfaces
+
+## How It Works
+
+1. **Pod Creation**: Deployment creates pod with multiple Multus network annotations
+2. **DRA Allocation**: DRA driver allocates 2 SR-IOV VFs based on resource claim
+3. **Multus Processing**: Multus CNI reads network annotations and DRA allocations
+4. **Interface Creation**: SR-IOV CNI plugin creates multiple network interfaces in pod
+5. **IP Assignment**: IPAM assigns IP addresses from configured subnet to each interface
+6. **Pod Ready**: Pod starts with cluster network plus multiple SR-IOV interfaces
+
+## Network Interface Behavior
+
+With Multus and multiple VFs:
+1. **Container Interfaces**:
+   - `eth0`: Default pod network (cluster networking)
+   - `net1`: First SR-IOV interface attached via Multus
+   - `net2`: Second SR-IOV interface attached via Multus
+
+2. **Traffic Routing Options**:
+   - Cluster traffic uses `eth0`
+   - Application can use `net1` and `net2` for:
+     - Active-backup configuration
+     - Load balancing
+     - Traffic segregation by type
+     - Bandwidth aggregation
+
+3. **Interface Management**:
+   - Each interface operates independently
+   - Same or different network configurations possible
+   - Individual IP addressing per interface
+
+## Use Cases
+
+Multus integration with multiple VFs is ideal for:
+- **Cloud-Native Network Functions**: CNFs requiring multiple data plane interfaces
+- **High Availability Networking**: Primary/backup interface configuration
+- **Multi-Tenant Applications**: Separate VFs for different tenants or services
+- **5G/Telco Workloads**: Multiple interfaces for N2, N3, N4, N6 interfaces
+- **Load Balancing**: Traffic distribution across multiple hardware-accelerated interfaces
+- **Network Segmentation**: Separate control and data plane networks
+- **Bandwidth Aggregation**: Combining multiple VFs for higher throughput
+
+## Multus Network Annotation Format
+
+The annotation `k8s.v1.cni.cncf.io/networks: vf-test1,vf-test1` specifies:
+- Comma-separated list of network attachment definitions
+- Each entry creates a separate network interface
+- Can reference the same or different NetworkAttachmentDefinitions
+- Order determines interface naming (net1, net2, etc.)
+
+Alternative annotation formats:
+```yaml
+# Same network, multiple times
+k8s.v1.cni.cncf.io/networks: vf-test1,vf-test1
+
+# Different networks
+k8s.v1.cni.cncf.io/networks: vf-control,vf-data
+
+# JSON format with interface names
+k8s.v1.cni.cncf.io/networks: |
+  [
+    {"name": "vf-test1", "interface": "dataplane1"},
+    {"name": "vf-test1", "interface": "dataplane2"}
+  ]
+```
+
+## Usage
+
+1. Deploy the configuration:
+   ```bash
+   kubectl apply -f multus-integration-multiple-vf.yaml
+   ```
+
+2. Verify deployment:
+   ```bash
+   kubectl get deployment -n vf-test8
+   kubectl get pods -n vf-test8
+   kubectl describe pod -n vf-test8 -l app=pod0
+   ```
+
+3. Check Multus network attachments:
+   ```bash
+   kubectl get network-attachment-definitions -n vf-test8
+   kubectl describe network-attachment-definitions vf-test1 -n vf-test8
+   ```
+
+4. Verify resource claims:
+   ```bash
+   kubectl get resourceclaim -n vf-test8
+   kubectl describe resourceclaim -n vf-test8
+   ```
+
+5. Check all network interfaces in the pod:
+   ```bash
+   # Get pod name
+   POD_NAME=$(kubectl get pods -n vf-test8 -l app=pod0 -o jsonpath='{.items[0].metadata.name}')
+   
+   # List all interfaces
+   kubectl exec -n vf-test8 $POD_NAME -- ip link show
+   
+   # Check all IP addresses
+   kubectl exec -n vf-test8 $POD_NAME -- ip addr show
+   
+   # Verify first SR-IOV interface
+   kubectl exec -n vf-test8 $POD_NAME -- ip addr show net1
+   
+   # Verify second SR-IOV interface
+   kubectl exec -n vf-test8 $POD_NAME -- ip addr show net2
+   ```
+
+6. Test connectivity on each interface:
+   ```bash
+   # Test cluster networking (eth0)
+   kubectl exec -n vf-test8 $POD_NAME -- ping -c 3 kubernetes.default.svc.cluster.local
+   
+   # Test first SR-IOV interface (net1)
+   kubectl exec -n vf-test8 $POD_NAME -- ping -I net1 -c 3 <target-ip>
+   
+   # Test second SR-IOV interface (net2)
+   kubectl exec -n vf-test8 $POD_NAME -- ping -I net2 -c 3 <target-ip>
+   ```
+
+7. Advanced networking tests:
+   ```bash
+   # Check routing table
+   kubectl exec -n vf-test8 $POD_NAME -- ip route show
+   
+   # Test bandwidth on each interface
+   kubectl exec -n vf-test8 $POD_NAME -- ethtool -S net1
+   kubectl exec -n vf-test8 $POD_NAME -- ethtool -S net2
+   
+   # Check interface statistics
+   kubectl exec -n vf-test8 $POD_NAME -- cat /proc/net/dev
+   ```
+
+## Resource Allocation Considerations
+
+When allocating multiple VFs:
+- **Availability**: Ensure sufficient VFs exist on target nodes
+- **NUMA Affinity**: VFs may come from different NUMA nodes
+- **Performance**: Consider NUMA locality for optimal performance
+- **PF Capacity**: Check Physical Function limits for VF count
+- **Network Topology**: Plan for network connectivity requirements
+
+## Deployment Characteristics
+
+- **Replicas**: Configured for 1 replica (scalable)
+- **Termination Grace Period**: 2 seconds for quick cleanup
+- **Security Context**: Runs as root with privilege escalation
+- **Resource Management**: Uses Kubernetes resource claims for VF allocation
+- **Network Isolation**: Each VF provides independent network path
+
+## Performance Considerations
+
+Multiple VF allocation impacts:
+- **Throughput**: Aggregate bandwidth across multiple interfaces
+- **Latency**: Consistent low latency per interface
+- **CPU Usage**: Slightly higher due to multi-interface management
+- **Memory**: Additional memory for per-interface buffers
+- **Scalability**: Plan for resource consumption per pod
+
+## Prerequisites
+
+- SR-IOV capable network interface with multiple VFs configured
+- SR-IOV Network Operator installed and configured
+- Multus CNI installed on the cluster
+- At least 2 Virtual Functions available per target node
+- DRA-enabled Kubernetes cluster (v1.34+)
+- Appropriate node labeling and SR-IOV configuration
+- IPAM with sufficient IP addresses for multiple interfaces
+
+## Troubleshooting
+
+Common issues and solutions:
+
+1. **Pod stuck in Pending**:
+   - Check if enough VFs are available: `kubectl get nodes -o json | grep -i allocatable`
+   - Verify resource claim status: `kubectl describe resourceclaim -n vf-test8`
+   - Check DRA driver logs for allocation errors
+
+2. **Only one network interface created**:
+   - Verify Multus annotation has correct format and count
+   - Check that resource claim allocated 2 VFs
+   - Review Multus CNI logs on the node
+
+3. **Network interfaces not configured**:
+   - Verify NetworkAttachmentDefinition: `kubectl describe net-attach-def vf-test1 -n vf-test8`
+   - Check SR-IOV CNI plugin installation and configuration
+   - Review pod events: `kubectl describe pod -n vf-test8 -l app=pod0`
+
+4. **IP assignment fails on one or more interfaces**:
+   - Check IPAM subnet has enough available IPs
+   - Verify IPAM configuration in NetworkAttachmentDefinition
+   - Review SR-IOV CNI logs for IPAM errors
+
+5. **Performance issues**:
+   - Check NUMA affinity: VFs from different NUMA nodes may impact performance
+   - Verify VF queue configuration
+   - Monitor interface statistics for drops or errors
+
+## Advanced Configuration Examples
+
+### Different Networks for Each VF
+```yaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vf-control
+  namespace: vf-test8
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vf-data
+  namespace: vf-test8
+---
+# In pod annotation:
+k8s.v1.cni.cncf.io/networks: vf-control,vf-data
+```
+
+### Custom Interface Names
+```yaml
+annotations:
+  k8s.v1.cni.cncf.io/networks: |
+    [
+      {"name": "vf-test1", "interface": "control"},
+      {"name": "vf-test1", "interface": "data"}
+    ]
+```
+
+## Related Demos
+
+- **multiple-vf-claim**: Multiple VF allocation without Multus
+- **multus-integration-single-vf**: Multus integration with single VF
+- **claim-for-deployment**: Deployment patterns with SR-IOV resources
+- **resource-alignment**: Advanced resource allocation and NUMA awareness
+

--- a/demo/multus-integration-multiple-vf/multus-integration-multiple-vf.yaml
+++ b/demo/multus-integration-multiple-vf/multus-integration-multiple-vf.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vf-test8
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vf-test1
+  namespace: vf-test8
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: sriov/vf
+spec:
+  config: |-
+    {
+        "cniVersion": "1.0.0",
+        "name": "vf-test1",
+        "type": "sriov",
+        "vlan": 0,
+        "spoofchk": "on",
+        "trust": "on",
+        "vlanQoS": 0,
+        "logLevel": "info",
+        "ipam": {
+            "type": "host-local",
+            "ranges": [
+                [
+                    {
+                        "subnet": "10.0.2.0/24"
+                    }
+                ]
+            ]
+        }
+    }
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: vf-test8
+  name: vf-test8
+spec:
+  spec:
+    devices:
+      requests:
+      - name: vf
+        exactly:
+          deviceClassName: sriovnetwork.k8snetworkplumbingwg.io
+          count: 2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: vf-test8
+  name: pod0
+  labels:
+    app: pod0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pod0
+  template:
+    metadata:
+      labels:
+        app: pod0
+      annotations:
+        k8s.v1.cni.cncf.io/networks: vf-test1,vf-test1
+    spec:
+      terminationGracePeriodSeconds: 2
+      containers:
+      - name: ctr0
+        image: quay.io/schseba/toolbox:latest
+        command:
+          - /bin/bash
+          - -c
+          - sleep INF
+        securityContext:
+          runAsUser: 0
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+              - NET_ADMIN
+              - NET_RAW
+        resources:
+          claims:
+          - name: sriov
+      resourceClaims:
+      - name: sriov
+        resourceClaimTemplateName: vf-test8

--- a/demo/multus-integration-single-vf/README.md
+++ b/demo/multus-integration-single-vf/README.md
@@ -1,0 +1,174 @@
+# Multus Integration with Single Virtual Function Demo
+
+This demo demonstrates the integration of DRA SR-IOV driver with Multus CNI for dynamic network attachment using a single Virtual Function.
+
+## Overview
+
+This scenario shows:
+- Integration between DRA (Dynamic Resource Allocation) and Multus CNI
+- Single SR-IOV Virtual Function allocation with Multus network attachment
+- Automatic network interface provisioning through Multus annotations
+- Deployment-based workload with SR-IOV networking
+
+## Components
+
+### 1. Namespace and Networking Setup
+- Creates dedicated namespace (`vf-test7`)
+- NetworkAttachmentDefinition with SR-IOV CNI plugin configuration
+- Multus resource annotation: `k8s.v1.cni.cncf.io/resourceName: sriov/vf`
+- IPAM setup using host-local plugin with subnet `10.0.2.0/24`
+- Standard SR-IOV network settings (VLAN 0, spoofchk on, trust on)
+
+### 2. Single VF Resource Claim
+The `ResourceClaimTemplate` configuration:
+- **count**: Implicitly 1 (single VF request)
+- **deviceClassName**: `sriovnetwork.k8snetworkplumbingwg.io`
+- Automatically integrates with Multus through DRA driver
+
+### 3. Deployment Configuration
+- Uses Deployment for production-like workload management
+- Single replica for testing purposes
+- Multus network annotation: `k8s.v1.cni.cncf.io/networks: vf-test1`
+- Container with necessary networking capabilities (NET_ADMIN, NET_RAW)
+- Resource claim binding for the single VF
+
+## Multus Integration Benefits
+
+This integration provides:
+- **Declarative Network Attachment**: Networks defined through annotations
+- **Dynamic Resource Management**: DRA handles VF allocation lifecycle
+- **Compatibility**: Works with existing Multus-aware applications
+- **Flexibility**: Easy migration path from traditional SR-IOV device plugin
+- **Multi-Network Support**: Foundation for complex multi-network scenarios
+
+## How It Works
+
+1. **Pod Creation**: Deployment creates pod with Multus network annotation
+2. **DRA Allocation**: DRA driver allocates SR-IOV VF based on resource claim
+3. **Multus Processing**: Multus CNI reads network annotation and DRA allocation
+4. **Interface Creation**: SR-IOV CNI plugin creates network interface in pod
+5. **IP Assignment**: IPAM assigns IP address from configured subnet
+6. **Pod Ready**: Pod starts with both cluster and SR-IOV networking
+
+## Network Interface Behavior
+
+With Multus and single VF:
+1. **Container Interfaces**:
+   - `eth0`: Default pod network (cluster networking)
+   - `net1`: SR-IOV interface attached via Multus (high-performance networking)
+
+2. **Traffic Routing**:
+   - Cluster traffic uses `eth0`
+   - Application data plane can use `net1` for SR-IOV acceleration
+   - Multus manages the lifecycle of additional network attachments
+
+## Use Cases
+
+Multus integration with single VF is ideal for:
+- **CNF Workloads**: Cloud-native network functions requiring hardware acceleration
+- **Migration from Device Plugin**: Moving from SR-IOV device plugin to DRA
+- **Hybrid Deployments**: Mixed workloads with varied networking requirements
+- **Telco Applications**: 5G/NFV workloads with control and data plane separation
+- **Performance-Critical Services**: Applications needing SR-IOV with Kubernetes orchestration
+
+## Usage
+
+1. Deploy the configuration:
+   ```bash
+   kubectl apply -f multus-integration-single-vf.yaml
+   ```
+
+2. Verify deployment:
+   ```bash
+   kubectl get deployment -n vf-test7
+   kubectl get pods -n vf-test7
+   kubectl describe pod -n vf-test7 -l app=pod0
+   ```
+
+3. Check Multus network attachments:
+   ```bash
+   kubectl get network-attachment-definitions -n vf-test7
+   kubectl describe network-attachment-definitions vf-test1 -n vf-test7
+   ```
+
+4. Verify resource claims:
+   ```bash
+   kubectl get resourceclaim -n vf-test7
+   kubectl describe resourceclaim -n vf-test7
+   ```
+
+5. Check network configuration in the pod:
+   ```bash
+   # Get pod name
+   POD_NAME=$(kubectl get pods -n vf-test7 -l app=pod0 -o jsonpath='{.items[0].metadata.name}')
+   
+   # List interfaces
+   kubectl exec -n vf-test7 $POD_NAME -- ip link show
+   
+   # Check IP addresses
+   kubectl exec -n vf-test7 $POD_NAME -- ip addr show
+   
+   # Verify SR-IOV interface
+   kubectl exec -n vf-test7 $POD_NAME -- ip addr show net1
+   ```
+
+6. Test network connectivity:
+   ```bash
+   # Test cluster networking (eth0)
+   kubectl exec -n vf-test7 $POD_NAME -- ping -c 3 kubernetes.default.svc.cluster.local
+   
+   # Test SR-IOV interface (net1) - requires target IP
+   kubectl exec -n vf-test7 $POD_NAME -- ping -I net1 -c 3 <target-ip>
+   ```
+
+## Key Differences from Traditional SR-IOV
+
+| Aspect | Traditional SR-IOV Device Plugin | DRA with Multus |
+|--------|----------------------------------|-----------------|
+| Resource Allocation | Device plugin framework | Dynamic Resource Allocation API |
+| Lifecycle Management | Static pool | Dynamic claim-based allocation |
+| Network Attachment | Multus resource annotation | DRA resource claim + Multus annotation |
+| Flexibility | Limited to device plugin model | Full Kubernetes resource model |
+| Extensibility | Device plugin constraints | Native Kubernetes resources |
+
+## Deployment Characteristics
+
+- **Replicas**: Configured for 1 replica (can be scaled)
+- **Termination Grace Period**: 2 seconds for quick cleanup
+- **Security Context**: Runs as root with privilege escalation for network setup
+- **Resource Management**: Uses Kubernetes resource claims for VF allocation
+
+## Prerequisites
+
+- SR-IOV capable network interface
+- SR-IOV Network Operator installed and configured
+- Multus CNI installed on the cluster
+- At least one Virtual Function available
+- DRA-enabled Kubernetes cluster (v1.34+)
+- Appropriate node labeling and SR-IOV configuration
+
+## Troubleshooting
+
+Common issues and solutions:
+
+1. **Pod stuck in Pending**:
+   - Check resource claim status: `kubectl describe resourceclaim -n vf-test7`
+   - Verify VF availability on nodes
+   - Check DRA driver logs
+
+2. **Network interface not created**:
+   - Verify NetworkAttachmentDefinition: `kubectl describe net-attach-def vf-test1 -n vf-test7`
+   - Check Multus CNI logs on the node
+   - Verify SR-IOV CNI plugin installation
+
+3. **IP assignment fails**:
+   - Check IPAM configuration in NetworkAttachmentDefinition
+   - Verify subnet availability
+   - Review SR-IOV CNI logs
+
+## Related Demos
+
+- **single-vf-claim**: Basic single VF allocation without Multus
+- **multus-integration-multiple-vf**: Multus integration with multiple VFs
+- **claim-for-deployment**: Deployment patterns with SR-IOV resources
+

--- a/demo/multus-integration-single-vf/multus-integration-single-vf.yaml
+++ b/demo/multus-integration-single-vf/multus-integration-single-vf.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vf-test7
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vf-test1
+  namespace: vf-test7
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: sriov/vf
+spec:
+  config: |-
+    {
+        "cniVersion": "1.0.0",
+        "name": "vf-test1",
+        "type": "sriov",
+        "vlan": 0,
+        "spoofchk": "on",
+        "trust": "on",
+        "vlanQoS": 0,
+        "logLevel": "info",
+        "ipam": {
+            "type": "host-local",
+            "ranges": [
+                [
+                    {
+                        "subnet": "10.0.2.0/24"
+                    }
+                ]
+            ]
+        }
+    }
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: vf-test7
+  name: vf-test7
+spec:
+  spec:
+    devices:
+      requests:
+      - name: vf
+        exactly:
+          deviceClassName: sriovnetwork.k8snetworkplumbingwg.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: vf-test7
+  name: pod0
+  labels:
+    app: pod0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pod0
+  template:
+    metadata:
+      labels:
+        app: pod0
+      annotations:
+        k8s.v1.cni.cncf.io/networks: vf-test1
+    spec:
+      terminationGracePeriodSeconds: 2
+      containers:
+      - name: ctr0
+        image: quay.io/schseba/toolbox:latest
+        command:
+          - /bin/bash
+          - -c
+          - sleep INF
+        securityContext:
+          runAsUser: 0
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+              - NET_ADMIN
+              - NET_RAW
+        resources:
+          claims:
+          - name: sriov
+      resourceClaims:
+      - name: sriov
+        resourceClaimTemplateName: vf-test7

--- a/deployments/helm/dra-driver-sriov/README.md
+++ b/deployments/helm/dra-driver-sriov/README.md
@@ -144,11 +144,21 @@ The kubelet plugin runs as a DaemonSet on all nodes where SR-IOV devices should 
 | `kubeletPlugin.nriPluginName` | string | `dra-driver-sriov` | Name of the NRI plugin |
 | `kubeletPlugin.nriPluginIndex` | int | `42` | Index of the NRI plugin (determines execution order) |
 | `kubeletPlugin.defaultInterfacePrefix` | string | `vfnet` | Default prefix for network interface names |
+| `kubeletPlugin.configurationMode` | string | `STANDALONE` | How the driver attaches networks. See [CONFIGURATION_MODE](#configuration_mode) for supported options. |
 | `kubeletPlugin.containers.init.securityContext` | object | `{}` | Security context for init container |
 | `kubeletPlugin.containers.init.resources` | object | `{}` | Resource requests/limits for init container |
 | `kubeletPlugin.containers.plugin.securityContext` | object | `{"privileged":true}` | Security context for plugin container (requires privileged) |
 | `kubeletPlugin.containers.plugin.resources` | object | `{}` | Resource requests/limits for plugin container |
 | `kubeletPlugin.containers.plugin.healthcheckPort` | int | `-1` | Port for health check (disabled if negative) |
+
+#### CONFIGURATION_MODE {#configuration_mode}
+
+`kubeletPlugin.configurationMode` controls how the driver attaches SR-IOV networks to pods. Set via the `CONFIGURATION_MODE` environment variable in the plugin container.
+
+| Value | Description |
+| ----- | ----------- |
+| `STANDALONE` | **(default)** The driver runs the SR-IOV CNI itself via the NRI (Node Resource Interface) plugin. Use when Multus is not in the pod network chain. Requires NRI to be enabled on the container runtime. |
+| `MULTUS` | The driver only prepares devices and updates the ResourceClaim; it does not run CNI. Multus is responsible for invoking the SR-IOV delegate CNI. Use when Multus is the primary CNI and attaches additional networks. NRI plugin is disabled in this mode. |
 
 ### Logging Parameters
 

--- a/deployments/helm/dra-driver-sriov/templates/dra-driver.yaml
+++ b/deployments/helm/dra-driver-sriov/templates/dra-driver.yaml
@@ -101,6 +101,8 @@ spec:
           value: {{ .Values.kubeletPlugin.nriPluginIndex | quote }}
         - name: DEFAULT_INTERFACE_PREFIX
           value: {{ .Values.kubeletPlugin.defaultInterfacePrefix | quote }}
+        - name: CONFIGURATION_MODE
+          value: {{ .Values.kubeletPlugin.configurationMode | quote }}
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/deployments/helm/dra-driver-sriov/values.yaml
+++ b/deployments/helm/dra-driver-sriov/values.yaml
@@ -58,6 +58,7 @@ kubeletPlugin:
   nriPluginName: dra-driver-sriov
   nriPluginIndex: 42
   defaultInterfacePrefix: vfnet
+  configurationMode: STANDALONE
   containers:
     init:
       securityContext: {}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -48,6 +48,9 @@ const (
 	DraNetCompatPrefix = "dra.net"
 	AttributeNUMANode  = DraNetCompatPrefix + "/numaNode"
 
+	MultusAttributePrefix   = "k8s.cni.cncf.io"
+	AttributeMultusDeviceID = MultusAttributePrefix + "/deviceID"
+
 	// Network device constants
 	NetClass  = 0x02 // Network controller class
 	SysBusPci = "/sys/bus/pci/devices"
@@ -65,6 +68,13 @@ const (
 var (
 	// AttributePCIeRoot identifies the PCIe root complex of the device
 	AttributePCIeRoot resourceapi.QualifiedName = deviceattribute.StandardDeviceAttributePCIeRoot
+)
+
+type ConfigurationMode string
+
+const (
+	ConfigurationModeStandalone ConfigurationMode = "STANDALONE"
+	ConfigurationModeMultus     ConfigurationMode = "MULTUS"
 )
 
 var Backoff = wait.Backoff{

--- a/pkg/devicestate/discovery.go
+++ b/pkg/devicestate/discovery.go
@@ -205,6 +205,9 @@ func DiscoverSriovDevices() (types.AllocatableDevices, error) {
 				consts.AttributeNUMANode: {
 					IntValue: numaNodeIntPtr,
 				},
+				consts.AttributeMultusDeviceID: {
+					StringValue: ptr.To(vfInfo.PciAddress),
+				},
 			}
 
 			resourceList[deviceName] = resourceapi.Device{

--- a/pkg/devicestate/state.go
+++ b/pkg/devicestate/state.go
@@ -37,6 +37,7 @@ type Manager struct {
 	// can be cleared without touching discovery attributes. Presence of a
 	// device key also indicates that the device is advertised (policy-matched).
 	policyAttrKeys map[string]map[resourceapi.QualifiedName]bool
+	configurationMode      string
 }
 
 func NewManager(config *drasriovtypes.Config, cdi *cdi.Handler) (*Manager, error) {
@@ -50,6 +51,7 @@ func NewManager(config *drasriovtypes.Config, cdi *cdi.Handler) (*Manager, error
 		defaultInterfacePrefix: config.Flags.DefaultInterfacePrefix,
 		cdi:                    cdi,
 		allocatable:            allocatable,
+		configurationMode:      config.Flags.ConfigurationMode,
 	}
 
 	return state, nil
@@ -105,7 +107,7 @@ func (s *Manager) prepareDevices(ctx context.Context, ifNameIndex *int,
 
 		config, ok := resultsConfig[result.Request]
 		if !ok {
-			return nil, fmt.Errorf("config not found for request: %s", result.Request)
+			config = configapi.DefaultVfConfig()
 		}
 
 		// make changes if needed
@@ -144,20 +146,23 @@ func (s *Manager) applyConfigOnDevice(ctx context.Context, ifNameIndex *int, cla
 		return nil, fmt.Errorf("device %s not found in allocatable devices", result.Device)
 	}
 
-	netAttachDefNamespace := claim.GetNamespace()
-	if config.NetAttachDefNamespace != "" {
-		netAttachDefNamespace = config.NetAttachDefNamespace
-	}
-
-	netAttachDefRawConfig, err := s.getNetAttachDefRawConfig(ctx, netAttachDefNamespace, config.NetAttachDefName)
-	if err != nil {
-		return nil, fmt.Errorf("error getting net attach def raw config: %w", err)
-	}
-	// add to sriov-cni compatible netconf the deviceID (PCI address)
+	var netAttachDefRawConfig string
+	var err error
 	pciAddress := *deviceInfo.Attributes[consts.AttributePciAddress].StringValue
-	netAttachDefRawConfig, err = drasriovtypes.AddDeviceIDToNetConf(netAttachDefRawConfig, pciAddress)
-	if err != nil {
-		return nil, fmt.Errorf("error converting net attach def config to sriov-cni format: %w", err)
+	if consts.ConfigurationMode(s.configurationMode) == consts.ConfigurationModeStandalone {
+		netAttachDefNamespace := claim.GetNamespace()
+		if config.NetAttachDefNamespace != "" {
+			netAttachDefNamespace = config.NetAttachDefNamespace
+		}
+		netAttachDefRawConfig, err = s.getNetAttachDefRawConfig(ctx, netAttachDefNamespace, config.NetAttachDefName)
+		if err != nil {
+			return nil, fmt.Errorf("error getting net attach def raw config: %w", err)
+		}
+		// add to sriov-cni compatible netconf the deviceID (PCI address)
+		netAttachDefRawConfig, err = drasriovtypes.AddDeviceIDToNetConf(netAttachDefRawConfig, pciAddress)
+		if err != nil {
+			return nil, fmt.Errorf("error converting net attach def config to sriov-cni format: %w", err)
+		}
 	}
 	// Bind device to driver if specified in config
 	originalDriver, err := host.GetHelpers().BindDeviceDriver(pciAddress, config)
@@ -237,7 +242,7 @@ func (s *Manager) applyConfigOnDevice(ctx context.Context, ifNameIndex *int, cla
 	ifName := config.IfName
 	// if the device name is not set, we use the default interface prefix
 	// and the interface index, we also bump the index.
-	if ifName == "" {
+	if consts.ConfigurationMode(s.configurationMode) == consts.ConfigurationModeStandalone && ifName == "" {
 		ifName = fmt.Sprintf("%s%d", s.defaultInterfacePrefix, *ifNameIndex)
 		*ifNameIndex++
 	}

--- a/pkg/devicestate/state_test.go
+++ b/pkg/devicestate/state_test.go
@@ -3,6 +3,7 @@ package devicestate
 import (
 	"context"
 	"fmt"
+	"os"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
@@ -11,6 +12,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -969,4 +971,48 @@ var _ = Describe("Manager", func() {
 			Expect(envs).To(BeNil())
 		})
 	})
+	Context("MULTUS/STANDALONE behavior", func() {
+		It("skips ifName generation and NetAttachDef fetch in MULTUS", func() {
+			tmp, err := os.MkdirTemp("", "cdi-root")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tmp)
+			cdiHandler, err := cdi.NewHandler(tmp)
+			Expect(err).ToNot(HaveOccurred())
+
+			s := &Manager{
+				k8sClient:              flags.ClientSets{},
+				defaultInterfacePrefix: "vfnet",
+				cdi:                    cdiHandler,
+				allocatable: drasriovtypes.AllocatableDevices{
+					"devA": {
+						Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+							"sriovnetwork.k8snetworkplumbingwg.io/pciAddress": {StringValue: strPtr("0000:00:00.1")},
+						},
+					},
+				},
+				configurationMode: string(consts.ConfigurationModeMultus),
+			}
+
+			claim := &resourceapi.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim1", Namespace: "ns1"},
+				Status: resourceapi.ResourceClaimStatus{
+					ReservedFor: []resourceapi.ResourceClaimConsumerReference{{UID: k8stypes.UID("poduid-1")}},
+				},
+			}
+			cfg := &configapi.VfConfig{NetAttachDefName: "nad1"} // should be ignored in MULTUS
+			ifIndex := 0
+			res := &resourceapi.DeviceRequestAllocationResult{Device: "devA", Pool: "pool1", Request: "req1"}
+
+			pd, err := s.applyConfigOnDevice(context.Background(), &ifIndex, claim, cfg, res)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pd).ToNot(BeNil())
+			// ifName should remain empty and index unchanged
+			Expect(pd.IfName).To(Equal(""))
+			Expect(ifIndex).To(Equal(0))
+			// NetAttachDefConfig should be empty
+			Expect(pd.NetAttachDefConfig).To(BeEmpty())
+		})
+	})
 })
+
+func strPtr(s string) *string { return &s }

--- a/pkg/devicestate/statehelpers.go
+++ b/pkg/devicestate/statehelpers.go
@@ -79,9 +79,7 @@ func getMapOfOpaqueDeviceConfigForDevice(
 			resultConfigs[request] = resultConfig
 		}
 	}
+
 	klog.V(3).InfoS("Result configs", "resultConfigs", resultConfigs)
-	if len(resultConfigs) == 0 {
-		return resultConfigs, fmt.Errorf("no configs constructed for driver")
-	}
 	return resultConfigs, nil
 }

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -243,7 +243,12 @@ func (h *Host) PCI() (*ghw.PCIInfo, error) {
 	return ghw.PCI()
 }
 
-// TryGetInterfaceName tries to find the network interface name based on PCI address
+// TryGetInterfaceName tries to find the network interface name based on PCI address.
+// When multiple interfaces share the same PCI device (e.g. the PF and its VF
+// representors in mlx5 legacy mode), the actual PF interface is identified by
+// the absence of "vf" in its phys_port_name sysfs attribute.  VF representors
+// have phys_port_name values like "pf0vf0", while the PF itself has an empty
+// value or a simple port index like "p0".
 func (h *Host) TryGetInterfaceName(pciAddr string) string {
 	netDir := buildSysBusPciPath(pciAddr, "net")
 	if _, err := os.Lstat(netDir); err != nil {
@@ -255,12 +260,26 @@ func (h *Host) TryGetInterfaceName(pciAddr string) string {
 		return ""
 	}
 
-	if len(fInfos) == 0 {
-		return ""
+	// Prefer an interface that is not a VF representor.  Fall back to the
+	// first entry if no non-representor interface is found.
+	fallback := ""
+	for _, fi := range fInfos {
+		name := fi.Name()
+		if fallback == "" {
+			fallback = name
+		}
+		physPortNamePath := buildSysPath(fmt.Sprintf("/sys/class/net/%s/phys_port_name", name))
+		data, err := os.ReadFile(physPortNamePath)
+		if err != nil {
+			// No phys_port_name – cannot be a representor; treat as PF.
+			return name
+		}
+		if !strings.Contains(string(data), "vf") {
+			return name
+		}
 	}
 
-	// Return the first network interface name found
-	return fInfos[0].Name()
+	return fallback
 }
 
 // GetNicSriovMode returns the interface mode (simplified implementation)

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -168,6 +168,61 @@ var _ = Describe("Host", func() {
 				interfaceName := h.TryGetInterfaceName("0000:01:00.0")
 				Expect(interfaceName).To(BeEmpty())
 			})
+
+			// Mellanox mlx5 in legacy SR-IOV mode exposes both the PF interface and
+			// its VF representors under the same PCI device's /net/ sysfs directory.
+			// The VF representor sorts first alphabetically (e.g. "eth0" < "eth_rail1"),
+			// so the function must use phys_port_name to pick the actual PF interface.
+
+			It("should skip VF representor and return PF interface when both share the same PCI device", func() {
+				// Mirrors the real DGX layout: 0000:0c:00.0/net/ contains
+				//   eth0       (VF representor, phys_port_name="pf0vf0")
+				//   eth_rail1  (PF interface,   phys_port_name="p0")
+				fs.Dirs = []string{
+					"sys/bus/pci/devices/0000:0c:00.0/net",
+					"sys/bus/pci/devices/0000:0c:00.0/net/eth0",
+					"sys/bus/pci/devices/0000:0c:00.0/net/eth_rail1",
+					"sys/class/net/eth0",
+					"sys/class/net/eth_rail1",
+				}
+				fs.Files = map[string][]byte{
+					"sys/class/net/eth0/phys_port_name":      []byte("pf0vf0\n"),
+					"sys/class/net/eth_rail1/phys_port_name": []byte("p0\n"),
+				}
+				tearDown = fs.Use()
+
+				interfaceName := h.TryGetInterfaceName("0000:0c:00.0")
+				Expect(interfaceName).To(Equal("eth_rail1"))
+			})
+
+			It("should return PF interface when phys_port_name is absent (no representors present)", func() {
+				// Single PF interface with no phys_port_name file → returned immediately.
+				fs.Dirs = []string{
+					"sys/bus/pci/devices/0000:01:00.0/net",
+					"sys/bus/pci/devices/0000:01:00.0/net/eth0",
+				}
+				// No sys/class/net/eth0/phys_port_name file.
+				tearDown = fs.Use()
+
+				interfaceName := h.TryGetInterfaceName("0000:01:00.0")
+				Expect(interfaceName).To(Equal("eth0"))
+			})
+
+			It("should fall back to first interface when all entries are VF representors", func() {
+				// Edge case: only representors in the net dir – return the first one as fallback.
+				fs.Dirs = []string{
+					"sys/bus/pci/devices/0000:01:00.0/net",
+					"sys/bus/pci/devices/0000:01:00.0/net/eth0",
+					"sys/class/net/eth0",
+				}
+				fs.Files = map[string][]byte{
+					"sys/class/net/eth0/phys_port_name": []byte("pf0vf0\n"),
+				}
+				tearDown = fs.Use()
+
+				interfaceName := h.TryGetInterfaceName("0000:01:00.0")
+				Expect(interfaceName).To(Equal("eth0"))
+			})
 		})
 
 		Context("GetNicSriovMode", func() {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -18,6 +18,7 @@ type Flags struct {
 	KubeletPluginsDirectoryPath   string
 	HealthcheckPort               int
 	DefaultInterfacePrefix        string
+	ConfigurationMode             string
 }
 
 type Config struct {


### PR DESCRIPTION
On Mellanox mlx5 NICs in legacy SR-IOV mode, the kernel exposes both the PF interface (e.g. eth_rail1) and its VF representor (e.g. eth0, phys_port_name="pf0vf0") under the same PCI device's /net/ sysfs directory.  TryGetInterfaceName was returning the first alphabetical entry, which picked the VF representor over the actual PF because '0' < '_'.  This caused AttributePFName to be set to "eth0" instead of "eth_rail1" for every discovered VF device, so all pfNames filters in SriovResourcePolicy matched zero devices and the ResourceSlice remained empty.

Fix by reading phys_port_name for each interface: entries whose value contains "vf" (e.g. "pf0vf0") are VF representors and are skipped. The first non-representor is returned; if every entry is a representor the first one is used as a fallback.

Add three unit tests covering the new behaviour.